### PR TITLE
bulk requestのエラーレスポンスも受け取れるように

### DIFF
--- a/lib/kintone/kintone_error.rb
+++ b/lib/kintone/kintone_error.rb
@@ -2,6 +2,9 @@ class Kintone::KintoneError < StandardError
   attr_reader :message_text, :id, :code, :http_status, :errors
 
   def initialize(messages, http_status)
+    if messages.has_key?('results')
+      messages = messages['results'].find { |message| message.has_key?('message') }
+    end
     @message_text = messages['message']
     @id = messages['id']
     @code = messages['code']

--- a/lib/kintone/kintone_error.rb
+++ b/lib/kintone/kintone_error.rb
@@ -2,7 +2,7 @@ class Kintone::KintoneError < StandardError
   attr_reader :message_text, :id, :code, :http_status, :errors
 
   def initialize(messages, http_status)
-    if messages.has_key?('results')
+    if messages.is_a?(Hash) && messages.has_key?('results')
       messages = messages['results'].find { |message| message.has_key?('message') }
     end
     @message_text = messages['message']

--- a/spec/kintone/kintone_error_spec.rb
+++ b/spec/kintone/kintone_error_spec.rb
@@ -89,5 +89,55 @@ describe Kintone::KintoneError do
         it { is_expected.to eq '必須です。' }
       end
     end
+
+    context 'bulk requestでValidation Errorが発生した場合' do
+      let(:messages) do
+        {
+          'results' =>
+            [
+              {
+                "code" => "CB_VA01",
+                "id" => "49ZYc7Nv0dbvJ7N4lVEu",
+                "message" => "入力内容が正しくありません。",
+                "errors" => {
+                  "record.取消"=> {
+                    "messages"=>["必須です。"]
+                  }
+                }
+              },
+              {}
+            ]
+          }
+      end
+
+      let(:http_status) { 400 }
+
+      it { is_expected.to eq '400 [CB_VA01] 入力内容が正しくありません。(49ZYc7Nv0dbvJ7N4lVEu)' }
+
+      describe '#message_text' do
+        subject { target.message_text }
+        it { is_expected.to eq '入力内容が正しくありません。' }
+      end
+
+      describe '#id' do
+        subject { target.id }
+        it { is_expected.to eq '49ZYc7Nv0dbvJ7N4lVEu' }
+      end
+
+      describe '#code' do
+        subject { target.code }
+        it { is_expected.to eq 'CB_VA01' }
+      end
+
+      describe '#http_status' do
+        subject { target.http_status }
+        it { is_expected.to eq 400 }
+      end
+
+      describe '#errors' do
+        subject { target.errors['record.取消']['messages'].first }
+        it { is_expected.to eq '必須です。' }
+      end
+    end
   end
 end


### PR DESCRIPTION
bulk request実行時は、results配下に配列でエラー情報が格納されるため、エラーメッセージ が取得できていなかったため、修正しました。
もしよろしければ取り込んでいただけますと嬉しいです。